### PR TITLE
arm_scmi: Fix infinite recursion in transport probe

### DIFF
--- a/patches-6.18/0003-firmware-arm_scmi-add-acpi-support-to-SCMI.patch
+++ b/patches-6.18/0003-firmware-arm_scmi-add-acpi-support-to-SCMI.patch
@@ -128,12 +128,12 @@ index 111111111111..222222222222 100644
  static void __tag##_dev_free(void *data)				       \
  {									       \
  	struct platform_device *spdev = data;				       \
-@@ -492,7 +493,7 @@ static int __tag##_probe(struct platform_device *pdev)			       \
+@@ -492,7 +493,8 @@ static int __tag##_probe(struct platform_device *pdev)			       \
  	if (!spdev)							       \
  		return -ENOMEM;						       \
  									       \
--	device_set_of_node_from_dev(&spdev->dev, dev);			       \
-+	device_set_node(&spdev->dev, dev->fwnode);			       \
++	spdev->dev.fwnode = dev->fwnode;			            \
+ 	device_set_of_node_from_dev(&spdev->dev, dev);			       \
  									       \
  	strans.supplier = dev;						       \
  	memcpy(&strans.desc, &(__desc), sizeof(strans.desc));		       \

--- a/patches-7.0/0003-firmware-arm_scmi-add-acpi-support-to-SCMI.patch
+++ b/patches-7.0/0003-firmware-arm_scmi-add-acpi-support-to-SCMI.patch
@@ -129,12 +129,12 @@ index 111111111111..222222222222 100644
  static void __tag##_dev_free(void *data)				       \
  {									       \
  	struct platform_device *spdev = data;				       \
-@@ -492,7 +493,7 @@ static int __tag##_probe(struct platform_device *pdev)			       \
+@@ -492,7 +493,8 @@ static int __tag##_probe(struct platform_device *pdev)			       \
  	if (!spdev)							       \
  		return -ENOMEM;						       \
  									       \
--	device_set_of_node_from_dev(&spdev->dev, dev);			       \
-+	device_set_node(&spdev->dev, dev->fwnode);			       \
++	spdev->dev.fwnode = dev->fwnode;			            \
+	device_set_of_node_from_dev(&spdev->dev, dev);			       \
  									       \
  	strans.supplier = dev;						       \
  	memcpy(&strans.desc, &(__desc), sizeof(strans.desc));		       \

--- a/patches-7.1/0003-firmware-arm_scmi-add-acpi-support-to-SCMI.patch
+++ b/patches-7.1/0003-firmware-arm_scmi-add-acpi-support-to-SCMI.patch
@@ -129,12 +129,12 @@ index 111111111111..222222222222 100644
  static void __tag##_dev_free(void *data)				       \
  {									       \
  	struct platform_device *spdev = data;				       \
-@@ -496,7 +497,7 @@ static int __tag##_probe(struct platform_device *pdev)			       \
+@@ -496,7 +497,8 @@ static int __tag##_probe(struct platform_device *pdev)			       \
  	if (!spdev)							       \
  		return -ENOMEM;						       \
  									       \
--	device_set_of_node_from_dev(&spdev->dev, dev);			       \
-+	device_set_node(&spdev->dev, dev->fwnode);			       \
++	spdev->dev.fwnode = dev->fwnode;			            \
+ 	device_set_of_node_from_dev(&spdev->dev, dev);			       \
  									       \
  	strans.supplier = dev;						       \
  	memcpy(&strans.desc, &(__desc), sizeof(strans.desc));		       \


### PR DESCRIPTION
Hi CIX-ians, thanks for your hard work! :) I'm trying to run your kernel by applying patches to my OS, and ran into an issue

When `DEFINE_SCMI_TRANSPORT_DRIVER()` creates an "arm-scmi" child device for each transport (SMC, mailbox, etc.), it also copies the parent's `dev->of_node` along with the rest of the fwnode. So the child ends up with the same OF node as its parent
When the child device is added, `platform_match()` calls `of_driver_match_device()`, sees the node matches the transport driver's `of_match_table`, and probes away spawning another "arm-scmi" -> another probe -> infinite recursion -> stack overflow
To break the cycle, keep the fwnode, but use `device_set_of_node_from_dev()` for of_node instead. This sets `of_node_reused = true`, so `of_match_device()` skips it and the transport driver never matches its own child.
Bonus: refcounting is now balanced too,, `device_set_of_node_from_dev()` does `of_node_get()`, which pairs with `of_node_put()` in `platform_device_release()`