### PR TITLE
sky1-audss: use optional reset for ACPI compat

### DIFF
--- a/patches-7.1/00051-clk-cix-add-sky1-audss-clock-controller.patch
+++ b/patches-7.1/00051-clk-cix-add-sky1-audss-clock-controller.patch
@@ -1070,7 +1070,7 @@ index 000000000000..111111111111
 +	priv->dev = dev;
 +	priv->devtype_data = devtype_data;
 +
-+	priv->rst_noc = devm_reset_control_get_exclusive(dev, NULL);
++	priv->rst_noc = devm_reset_control_get_optional_exclusive(dev, NULL);
 +	if (IS_ERR(priv->rst_noc))
 +		return dev_err_probe(dev, PTR_ERR(priv->rst_noc),
 +				     "failed to get audss noc reset");


### PR DESCRIPTION
I hit a wall adapting the kernel because of incomplete DT, so scrolling through to look for bugs

On ACPI there is no resets _DSD entry, firmware handles NOC reset via _PS0. Switch to `devm_reset_control_get_optional_exclusive()` so that probe does not fail when the reset line is absent.