### PR TITLE
drm: Fix UB in drm_plane_mask() for >32 planes

### DIFF
--- a/0000-drm-plane-mask-u64.patch
+++ b/0000-drm-plane-mask-u64.patch
@@ -1,0 +1,39 @@
+diff --git a/include/drm/drm_plane.h b/include/drm/drm_plane.h
+--- a/include/drm/drm_plane.h
++++ b/include/drm/drm_plane.h
+@@ -940,9 +940,9 @@
+  * drm_plane_mask - find the mask of a registered plane
+  * @plane: plane to find mask for
+  */
+-static inline u32 drm_plane_mask(const struct drm_plane *plane)
++static inline u64 drm_plane_mask(const struct drm_plane *plane)
+ {
+-	return 1 << drm_plane_index(plane);
++	return 1ULL << drm_plane_index(plane);
+ }
+ 
+ struct drm_plane * drm_plane_from_index(struct drm_device *dev, int idx);
+diff --git a/include/drm/drm_crtc.h b/include/drm/drm_crtc.h
+--- a/include/drm/drm_crtc.h
++++ b/include/drm/drm_crtc.h
+@@ -192,7 +192,7 @@
+ 	 * @plane_mask: Bitmask of drm_plane_mask(plane) of planes attached to
+ 	 * this CRTC.
+ 	 */
+-	u32 plane_mask;
++	u64 plane_mask;
+ 
+ 	/**
+ 	 * @connector_mask: Bitmask of drm_connector_mask(connector) of
+diff --git a/drivers/gpu/drm/drm_atomic.c b/drivers/gpu/drm/drm_atomic.c
+--- a/drivers/gpu/drm/drm_atomic.c
++++ b/drivers/gpu/drm/drm_atomic.c
+@@ -471,7 +471,7 @@
+ 	drm_printf(p, "\tactive_changed=%d\n", state->active_changed);
+ 	drm_printf(p, "\tconnectors_changed=%d\n", state->connectors_changed);
+ 	drm_printf(p, "\tcolor_mgmt_changed=%d\n", state->color_mgmt_changed);
+-	drm_printf(p, "\tplane_mask=%x\n", state->plane_mask);
++	drm_printf(p, "\tplane_mask=%llx\n", state->plane_mask);
+ 	drm_printf(p, "\tconnector_mask=%x\n", state->connector_mask);
+ 	drm_printf(p, "\tencoder_mask=%x\n", state->encoder_mask);
+ 	drm_printf(p, "\tmode: " DRM_MODE_FMT "\n", DRM_MODE_ARG(&state->mode));


### PR DESCRIPTION
When linlondp driver registers 40 planes, a plane with index >= 32 triggers shift-out-of-bounds UB

Patch [00101-drm-linlondp-merge-updates-from-26q2.patch](https://github.com/cixtech/cix-linux-main/blob/main/patches-7.1/00101-drm-linlondp-merge-updates-from-26q2.patch) already attempted a partial fix, but never changed the struct field or the mask function itself
Patch [1009-linlondp-fix-WERROR.patch](https://github.com/cixtech/cix-linux-main/blob/19f2947303670f2e5734d6a96ffc72a80fd9b942/patches-7.1/1009-linlondp-fix-WERROR.patch#L312-L313) then reverted `%llx` back to `%x`, likely to suppress a `-Wformat -Werror` since `plane_mask` was still `u32`, leaving the UB unfixed