### PR TITLE
cix: Fix ref_clk/ddr_data error checks

### DIFF
--- a/patches-6.18/0024-phy-add-cix-phy-driver.patch
+++ b/patches-6.18/0024-phy-add-cix-phy-driver.patch
@@ -1183,9 +1183,9 @@ index 000000000000..111111111111
 +	}
 +
 +	u3phy->ref_clk = devm_clk_get(dev, "ref_clk");
-+	if (IS_ERR(u3phy->apb_clk)) {
-+		dev_err(dev, "phy apb clock not found\n");
-+		return PTR_ERR(u3phy->apb_clk);
++	if (IS_ERR(u3phy->ref_clk)) {
++		dev_err(dev, "phy ref clock not found\n");
++		return PTR_ERR(u3phy->ref_clk);
 +	}
 +
 +	u3phy->base = devm_platform_ioremap_resource(pdev, 0);

--- a/patches-6.18/0066-add-cix_dst-driver.patch
+++ b/patches-6.18/0066-add-cix_dst-driver.patch
@@ -12616,7 +12616,7 @@ index 000000000000..111111111111
 +	}
 +
 +	ddr_data = kzalloc(sizeof(*ddr_data), GFP_KERNEL);
-+	if (IS_ERR_OR_NULL(vaddr)) {
++	if (IS_ERR_OR_NULL(ddr_data)) {
 +		err = -ENOMEM;
 +		goto unmap;
 +	}

--- a/patches-6.18/0066-add-cix_dst-driver.patch
+++ b/patches-6.18/0066-add-cix_dst-driver.patch
@@ -12616,7 +12616,7 @@ index 000000000000..111111111111
 +	}
 +
 +	ddr_data = kzalloc(sizeof(*ddr_data), GFP_KERNEL);
-+	if (IS_ERR_OR_NULL(ddr_data)) {
++	if (!ddr_data) {
 +		err = -ENOMEM;
 +		goto unmap;
 +	}

--- a/patches-7.0/0024-phy-add-cix-phy-driver.patch
+++ b/patches-7.0/0024-phy-add-cix-phy-driver.patch
@@ -1183,10 +1183,9 @@ index 000000000000..111111111111
 +	}
 +
 +	u3phy->ref_clk = devm_clk_get(dev, "ref_clk");
-+	if (IS_ERR(u3phy->apb_clk)) {
-+		dev_err(dev, "phy apb clock not found\n");
-+		return PTR_ERR(u3phy->apb_clk);
-+	}
++	if (IS_ERR(u3phy->ref_clk)) {
++		dev_err(dev, "phy ref clock not found\n");
++		return PTR_ERR(u3phy->ref_clk);
 +
 +	u3phy->base = devm_platform_ioremap_resource(pdev, 0);
 +	if (IS_ERR(u3phy->base))

--- a/patches-7.0/0066-add-cix_dst-driver.patch
+++ b/patches-7.0/0066-add-cix_dst-driver.patch
@@ -12616,7 +12616,7 @@ index 000000000000..111111111111
 +	}
 +
 +	ddr_data = kzalloc(sizeof(*ddr_data), GFP_KERNEL);
-+	if (IS_ERR_OR_NULL(vaddr)) {
++	if (IS_ERR_OR_NULL(ddr_data)) {
 +		err = -ENOMEM;
 +		goto unmap;
 +	}

--- a/patches-7.0/0066-add-cix_dst-driver.patch
+++ b/patches-7.0/0066-add-cix_dst-driver.patch
@@ -12616,7 +12616,7 @@ index 000000000000..111111111111
 +	}
 +
 +	ddr_data = kzalloc(sizeof(*ddr_data), GFP_KERNEL);
-+	if (IS_ERR_OR_NULL(ddr_data)) {
++	if (!ddr_data) {
 +		err = -ENOMEM;
 +		goto unmap;
 +	}

--- a/patches-7.1/0024-phy-add-cix-phy-driver.patch
+++ b/patches-7.1/0024-phy-add-cix-phy-driver.patch
@@ -1183,9 +1183,9 @@ index 000000000000..111111111111
 +	}
 +
 +	u3phy->ref_clk = devm_clk_get(dev, "ref_clk");
-+	if (IS_ERR(u3phy->apb_clk)) {
-+		dev_err(dev, "phy apb clock not found\n");
-+		return PTR_ERR(u3phy->apb_clk);
++	if (IS_ERR(u3phy->ref_clk)) {
++		dev_err(dev, "phy ref clock not found\n");
++		return PTR_ERR(u3phy->ref_clk);
 +	}
 +
 +	u3phy->base = devm_platform_ioremap_resource(pdev, 0);

--- a/patches-7.1/0066-add-cix_dst-driver.patch
+++ b/patches-7.1/0066-add-cix_dst-driver.patch
@@ -12616,7 +12616,7 @@ index 000000000000..111111111111
 +	}
 +
 +	ddr_data = kzalloc(sizeof(*ddr_data), GFP_KERNEL);
-+	if (IS_ERR_OR_NULL(vaddr)) {
++	if (IS_ERR_OR_NULL(ddr_data)) {
 +		err = -ENOMEM;
 +		goto unmap;
 +	}

--- a/patches-7.1/0066-add-cix_dst-driver.patch
+++ b/patches-7.1/0066-add-cix_dst-driver.patch
@@ -12616,7 +12616,7 @@ index 000000000000..111111111111
 +	}
 +
 +	ddr_data = kzalloc(sizeof(*ddr_data), GFP_KERNEL);
-+	if (IS_ERR_OR_NULL(ddr_data)) {
++	if (!ddr_data) {
 +		err = -ENOMEM;
 +		goto unmap;
 +	}


### PR DESCRIPTION
During copy-paste refactoring, several error checks were not updated to match their new context
  
- `apb_clk` => `ref_clk`
- `vaddr` => `ddr_data`
