### PR TITLE
clocksource: sky1-gpt: Use ERR_PTR check for ioremap

### DIFF
--- a/patches-6.18/0012-irqchip-add-cix-sky1-pdc-driver.patch
+++ b/patches-6.18/0012-irqchip-add-cix-sky1-pdc-driver.patch
@@ -267,10 +267,10 @@ index 000000000000..111111111111
 +	raw_spin_lock_init(&cd->rlock);
 +	struct resource *res_dp = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 +	cd->pdc_base = devm_ioremap_resource(&pdev->dev, res_dp);
-+	if (!cd->pdc_base) {
++	if (IS_ERR(cd->pdc_base)) {
 +		pr_err("%pACPI: unable to map pdc registers\n", pdev);
 +		kfree(cd);
-+		return -ENOMEM;
++		return PTR_ERR(cd->pdc_base);
 +	}
 +
 +	domain = acpi_irq_create_hierarchy(0, PDC_MAX_IRQS, pdev->dev.fwnode,

--- a/patches-6.18/0045-clocksource-add-sky1-gpt-timer-driver.patch
+++ b/patches-6.18/0045-clocksource-add-sky1-gpt-timer-driver.patch
@@ -364,8 +364,8 @@ index 000000000000..111111111111
 +
 +	/* Acpi resource parse */
 +	sky1tm->base = devm_platform_ioremap_resource(pdev, 0);
-+	if (!sky1tm->base)
-+		return -ENXIO;
++	if (IS_ERR(sky1tm->base))
++		return PTR_ERR(sky1tm->base);
 +
 +	sky1tm->irq = platform_get_irq(pdev, 0);
 +	if (sky1tm->irq <= 0)

--- a/patches-7.0/0012-irqchip-add-cix-sky1-pdc-driver.patch
+++ b/patches-7.0/0012-irqchip-add-cix-sky1-pdc-driver.patch
@@ -271,10 +271,10 @@ index 000000000000..111111111111
 +	raw_spin_lock_init(&cd->rlock);
 +	struct resource *res_dp = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 +	cd->pdc_base = devm_ioremap_resource(&pdev->dev, res_dp);
-+	if (!cd->pdc_base) {
++	if (IS_ERR(cd->pdc_base)) {
 +		pr_err("%pACPI: unable to map pdc registers\n", pdev);
 +		kfree(cd);
-+		return -ENOMEM;
++		return PTR_ERR(cd->pdc_base);
 +	}
 +
 +	domain = acpi_irq_create_hierarchy(0, PDC_MAX_IRQS, pdev->dev.fwnode,

--- a/patches-7.0/0045-clocksource-add-sky1-gpt-timer-driver.patch
+++ b/patches-7.0/0045-clocksource-add-sky1-gpt-timer-driver.patch
@@ -364,8 +364,8 @@ index 000000000000..111111111111
 +
 +	/* Acpi resource parse */
 +	sky1tm->base = devm_platform_ioremap_resource(pdev, 0);
-+	if (!sky1tm->base)
-+		return -ENXIO;
++	if (IS_ERR(sky1tm->base))
++		return PTR_ERR(sky1tm->base);
 +
 +	sky1tm->irq = platform_get_irq(pdev, 0);
 +	if (sky1tm->irq <= 0)

--- a/patches-7.1/0012-irqchip-add-cix-sky1-pdc-driver.patch
+++ b/patches-7.1/0012-irqchip-add-cix-sky1-pdc-driver.patch
@@ -271,10 +271,10 @@ index 000000000000..111111111111
 +	raw_spin_lock_init(&cd->rlock);
 +	struct resource *res_dp = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 +	cd->pdc_base = devm_ioremap_resource(&pdev->dev, res_dp);
-+	if (!cd->pdc_base) {
++	if (IS_ERR(cd->pdc_base)) {
 +		pr_err("%pACPI: unable to map pdc registers\n", pdev);
 +		kfree(cd);
-+		return -ENOMEM;
++		return PTR_ERR(cd->pdc_base);
 +	}
 +
 +	domain = acpi_irq_create_hierarchy(0, PDC_MAX_IRQS, pdev->dev.fwnode,

--- a/patches-7.1/0045-clocksource-add-sky1-gpt-timer-driver.patch
+++ b/patches-7.1/0045-clocksource-add-sky1-gpt-timer-driver.patch
@@ -364,8 +364,8 @@ index 000000000000..111111111111
 +
 +	/* Acpi resource parse */
 +	sky1tm->base = devm_platform_ioremap_resource(pdev, 0);
-+	if (!sky1tm->base)
-+		return -ENXIO;
++	if (IS_ERR(sky1tm->base))
++		return PTR_ERR(sky1tm->base);
 +
 +	sky1tm->irq = platform_get_irq(pdev, 0);
 +	if (sky1tm->irq <= 0)


### PR DESCRIPTION
`devm_platform_ioremap_resource()` returns `ERR_PTR` on error, so the `!sky1tm->base` check and `!cd->pdc_base` check don't catch it. Add proper error validation for ioremap