### PR TITLE
pinctrl: Fix early return in sky1_pinconf_group_dbg_show

### DIFF
--- a/patches-6.18/00485-pinctrl-sky1-add-acpi-support.patch
+++ b/patches-6.18/00485-pinctrl-sky1-add-acpi-support.patch
@@ -31,7 +31,7 @@ diff --git a/drivers/pinctrl/cix/pinctrl-sky1-base.c b/drivers/pinctrl/cix/pinct
 index 111111111111..222222222222 100644
 --- a/drivers/pinctrl/cix/pinctrl-sky1-base.c
 +++ b/drivers/pinctrl/cix/pinctrl-sky1-base.c
-@@ -1,503 +1,719 @@
+@@ -1,503 +1,715 @@
  // SPDX-License-Identifier: GPL-2.0+
  //
  // Author: Jerry Zhu <Jerry.Zhu@cixtech.com>

--- a/patches-6.18/00485-pinctrl-sky1-add-acpi-support.patch
+++ b/patches-6.18/00485-pinctrl-sky1-add-acpi-support.patch
@@ -31,7 +31,7 @@ diff --git a/drivers/pinctrl/cix/pinctrl-sky1-base.c b/drivers/pinctrl/cix/pinct
 index 111111111111..222222222222 100644
 --- a/drivers/pinctrl/cix/pinctrl-sky1-base.c
 +++ b/drivers/pinctrl/cix/pinctrl-sky1-base.c
-@@ -1,503 +1,711 @@
+@@ -1,503 +1,719 @@
  // SPDX-License-Identifier: GPL-2.0+
  //
  // Author: Jerry Zhu <Jerry.Zhu@cixtech.com>
@@ -594,6 +594,9 @@ index 111111111111..222222222222 100644
  {
 -	return ARRAY_SIZE(sky1_gpio_functions);
 +	struct sky1_pinctrl *spctl = pinctrl_dev_get_drvdata(pctldev);
++
++	if (spctl->pin_regs[pin_id] == -1)
++		return -EINVAL;
 +	*config = readl(spctl->base + spctl->pin_regs[pin_id]);
 +
 +	return 0;
@@ -675,6 +678,7 @@ index 111111111111..222222222222 100644
 +
 +		name = pin_get_name(pctldev, pin_id);
 +		ret = sky1_pinconf_get(pctldev, pin_id, &config);
++		if (ret)
 +			return;
 +		seq_printf(s, "  %s: 0x%lx\n", name, config);
 +	}

--- a/patches-7.0/0048-pinctrl-sky1-add-acpi-support.patch
+++ b/patches-7.0/0048-pinctrl-sky1-add-acpi-support.patch
@@ -1203,7 +1203,7 @@ diff --git a/drivers/pinctrl/cix/pinctrl-sky1.c b/drivers/pinctrl/cix/pinctrl-sk
 index 111111111111..222222222222 100644
 --- a/drivers/pinctrl/cix/pinctrl-sky1.c
 +++ b/drivers/pinctrl/cix/pinctrl-sky1.c
-@@ -1,494 +1,437 @@
+@@ -1,494 +1,441 @@
  // SPDX-License-Identifier: GPL-2.0
 -//
 -// Author: Jerry Zhu <Jerry.Zhu@cixtech.com>

--- a/patches-7.0/0048-pinctrl-sky1-add-acpi-support.patch
+++ b/patches-7.0/0048-pinctrl-sky1-add-acpi-support.patch
@@ -594,6 +594,9 @@ index 111111111111..222222222222 100644
  {
 -	return ARRAY_SIZE(sky1_gpio_functions);
 +	struct sky1_pinctrl *spctl = pinctrl_dev_get_drvdata(pctldev);
++
++	if (spctl->pin_regs[pin_id] == -1)
++		return -EINVAL;
 +	*config = readl(spctl->base + spctl->pin_regs[pin_id]);
 +
 +	return 0;
@@ -675,6 +678,7 @@ index 111111111111..222222222222 100644
 +
 +		name = pin_get_name(pctldev, pin_id);
 +		ret = sky1_pinconf_get(pctldev, pin_id, &config);
++		if (ret)
 +			return;
 +		seq_printf(s, "  %s: 0x%lx\n", name, config);
 +	}

--- a/patches-7.0/0048-pinctrl-sky1-add-acpi-support.patch
+++ b/patches-7.0/0048-pinctrl-sky1-add-acpi-support.patch
@@ -31,7 +31,7 @@ diff --git a/drivers/pinctrl/cix/pinctrl-sky1-base.c b/drivers/pinctrl/cix/pinct
 index 111111111111..222222222222 100644
 --- a/drivers/pinctrl/cix/pinctrl-sky1-base.c
 +++ b/drivers/pinctrl/cix/pinctrl-sky1-base.c
-@@ -1,503 +1,711 @@
+@@ -1,503 +1,715 @@
  // SPDX-License-Identifier: GPL-2.0+
  //
  // Author: Jerry Zhu <Jerry.Zhu@cixtech.com>
@@ -1203,7 +1203,7 @@ diff --git a/drivers/pinctrl/cix/pinctrl-sky1.c b/drivers/pinctrl/cix/pinctrl-sk
 index 111111111111..222222222222 100644
 --- a/drivers/pinctrl/cix/pinctrl-sky1.c
 +++ b/drivers/pinctrl/cix/pinctrl-sky1.c
-@@ -1,494 +1,441 @@
+@@ -1,494 +1,437 @@
  // SPDX-License-Identifier: GPL-2.0
 -//
 -// Author: Jerry Zhu <Jerry.Zhu@cixtech.com>

--- a/patches-7.1/0048-pinctrl-sky1-add-acpi-support.patch
+++ b/patches-7.1/0048-pinctrl-sky1-add-acpi-support.patch
@@ -31,7 +31,7 @@ diff --git a/drivers/pinctrl/cix/pinctrl-sky1-base.c b/drivers/pinctrl/cix/pinct
 index 111111111111..222222222222 100644
 --- a/drivers/pinctrl/cix/pinctrl-sky1-base.c
 +++ b/drivers/pinctrl/cix/pinctrl-sky1-base.c
-@@ -1,503 +1,711 @@
+@@ -1,503 +1,715 @@
  // SPDX-License-Identifier: GPL-2.0+
  //
  // Author: Jerry Zhu <Jerry.Zhu@cixtech.com>
@@ -594,6 +594,9 @@ index 111111111111..222222222222 100644
  {
 -	return ARRAY_SIZE(sky1_gpio_functions);
 +	struct sky1_pinctrl *spctl = pinctrl_dev_get_drvdata(pctldev);
++
++	if (spctl->pin_regs[pin_id] == -1)
++		return -EINVAL;
 +	*config = readl(spctl->base + spctl->pin_regs[pin_id]);
 +
 +	return 0;
@@ -675,6 +678,7 @@ index 111111111111..222222222222 100644
 +
 +		name = pin_get_name(pctldev, pin_id);
 +		ret = sky1_pinconf_get(pctldev, pin_id, &config);
++		if (ret)
 +			return;
 +		seq_printf(s, "  %s: 0x%lx\n", name, config);
 +	}


### PR DESCRIPTION
In `sky1_pinconf_get()`: add a guard for `pin_regs[pin_id] == -1` and return `-EINVAL`, without it, unconfigured pins lead to an invalid `readl(base + 0xFFFFFFFF)` access

In `sky1_pinconf_group_dbg_show()`: the unconditional `return` inside the loop was intended to be conditional. I believe it should have been `if (ret) return`, as the extra indent level suggests the author’s intent, so the logic is updated to match the mainline `imx_pinconf_group_dbg_show` pattern